### PR TITLE
Add DeepSeek defaults and key info extraction

### DIFF
--- a/src/main/java/com/example/MrPot/model/AttachmentContext.java
+++ b/src/main/java/com/example/MrPot/model/AttachmentContext.java
@@ -25,7 +25,8 @@ public record AttachmentContext(
                 "url", f.uri().toString(),
                 "preview", f.preview(previewChars),
                 "chars", f.extractedText() == null ? 0 : f.extractedText().length(),
-                "error", f.error() == null ? "" : f.error()
+                "error", f.error() == null ? "" : f.error(),
+                "keyInfo", f.keyInfoJson() == null ? "" : f.keyInfoJson()
         )).toList();
     }
 }

--- a/src/main/java/com/example/MrPot/model/ExtractedFile.java
+++ b/src/main/java/com/example/MrPot/model/ExtractedFile.java
@@ -1,6 +1,8 @@
 package com.example.MrPot.model;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 
 public record ExtractedFile(
         URI uri,
@@ -8,12 +10,33 @@ public record ExtractedFile(
         String mimeType,
         long sizeBytes,
         String extractedText,
-        String error
+        String error,
+        String keyInfoJson,
+        List<String> entities
 ) {
     public String preview(int maxChars) {
         if (extractedText == null) return "";
         return extractedText.length() <= maxChars
                 ? extractedText
                 : extractedText.substring(0, maxChars) + "...";
+    }
+
+    public ExtractedFile withKeyInfo(String keyInfoJson, List<String> entities) {
+        List<String> safeEntities = entities == null ? List.of() : List.copyOf(entities);
+        return new ExtractedFile(
+                uri,
+                filename,
+                mimeType,
+                sizeBytes,
+                extractedText,
+                error,
+                keyInfoJson,
+                safeEntities
+        );
+    }
+
+    public List<String> entitiesOrEmpty() {
+        if (entities == null) return List.of();
+        return Collections.unmodifiableList(entities);
     }
 }

--- a/src/main/java/com/example/MrPot/model/RagAnswerRequest.java
+++ b/src/main/java/com/example/MrPot/model/RagAnswerRequest.java
@@ -29,6 +29,7 @@ public record RagAnswerRequest(
 ) {
     private static final Set<String> models = Set.of("deepseek", "gemini", "openai");
     public static final String DEFAULT_MODEL = "deepseek";
+    public static final String DEFAULT_VISION_MODEL = "deepseek";
 
     public int resolveTopK(int defaultValue) {
         return topK == null || topK <= 0 ? defaultValue : topK;
@@ -53,7 +54,7 @@ public record RagAnswerRequest(
 
     public String resolveVisionModelOrNull() {
         String key = normalizeModelKey(visionModel);
-        return (key == null || !models.contains(key)) ? DEFAULT_MODEL : key;
+        return (key == null || !models.contains(key)) ? DEFAULT_VISION_MODEL : key;
     }
 
     private static String normalizeModelKey(String s) {

--- a/src/main/java/com/example/MrPot/service/AttachmentService.java
+++ b/src/main/java/com/example/MrPot/service/AttachmentService.java
@@ -2,18 +2,28 @@ package com.example.MrPot.service;
 
 import com.example.MrPot.model.AttachmentContext;
 import com.example.MrPot.model.ExtractedFile;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class AttachmentService {
 
     private static final int MAX_FILES = 3;
+    private static final int MAX_KEY_INFO_INPUT_CHARS = 4500;
+    private static final int MAX_ENTITY_COUNT = 12;
+    private static final ObjectMapper OM = new ObjectMapper();
 
     private final RemoteFileService remote;
     private final FileExtractionService extractor;
@@ -23,7 +33,7 @@ public class AttachmentService {
         this.extractor = extractor;
     }
 
-    public Mono<AttachmentContext> fetchAndExtract(List<String> urls, ChatClient visionClientOrNull) {
+    public Mono<AttachmentContext> fetchAndExtract(List<String> urls, ChatClient visionClientOrNull, ChatClient keyInfoClient) {
         if (urls == null || urls.isEmpty()) return Mono.just(AttachmentContext.empty());
 
         return Flux.fromIterable(urls)
@@ -32,6 +42,7 @@ public class AttachmentService {
                 .concatMap(url ->
                         remote.download(url)
                                 .flatMap(df -> extractor.extract(df, visionClientOrNull))
+                                .flatMap(f -> enrichWithKeyInfo(f, keyInfoClient))
                                 // English comments: One file failure should not kill the whole batch.
                                 .onErrorResume(ex -> Mono.just(failed(url, ex)))
                 )
@@ -51,7 +62,66 @@ public class AttachmentService {
                 "application/octet-stream",
                 0L,
                 "",
-                String.valueOf(ex)
+                String.valueOf(ex),
+                null,
+                List.of()
         );
+    }
+
+    private Mono<ExtractedFile> enrichWithKeyInfo(ExtractedFile file, ChatClient keyInfoClient) {
+        if (file == null) return Mono.just(file);
+        if (keyInfoClient == null) return Mono.just(file);
+        if (file.error() != null && !file.error().isBlank()) return Mono.just(file);
+
+        String text = Optional.ofNullable(file.extractedText()).orElse("").trim();
+        if (text.isBlank()) return Mono.just(file);
+
+        String clipped = text.length() > MAX_KEY_INFO_INPUT_CHARS
+                ? text.substring(0, MAX_KEY_INFO_INPUT_CHARS)
+                : text;
+
+        String prompt = "Extract key details from the document text. Respond with compact JSON only matching this schema:\n" +
+                "{\n" +
+                "  \"title\": \"\",\n" +
+                "  \"doc_type\": \"\",\n" +
+                "  \"summary_bullets\": [\"...\"],\n" +
+                "  \"key_facts\": [{\"fact\":\"...\",\"evidence\":\"...\"}],\n" +
+                "  \"entities\": [{\"type\":\"person|org|date|amount|other\",\"value\":\"...\"}],\n" +
+                "  \"action_items\": [{\"task\":\"...\",\"due_date\":\"\"}]\n" +
+                "}\n" +
+                "Rules: base everything on the provided text; keep evidence short; output valid JSON only.\n\n" +
+                "CONTENT:\n" + clipped;
+
+        return Mono.fromCallable(() -> {
+                    String keyInfoJson = keyInfoClient.prompt()
+                            .user(prompt)
+                            .call()
+                            .content();
+
+                    List<String> entities = parseEntityValues(keyInfoJson, MAX_ENTITY_COUNT);
+                    return file.withKeyInfo(keyInfoJson, entities);
+                })
+                .onErrorReturn(file);
+    }
+
+    private static List<String> parseEntityValues(String json, int max) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            JsonNode root = OM.readTree(json);
+            JsonNode entitiesNode = root.path("entities");
+            if (!entitiesNode.isArray()) return List.of();
+
+            Set<String> set = new LinkedHashSet<>();
+            for (JsonNode n : (ArrayNode) entitiesNode) {
+                if (!n.isObject()) continue;
+                String v = n.path("value").asText("").trim();
+                if (v.isEmpty()) continue;
+                set.add(v);
+                if (set.size() >= max) break;
+            }
+            return new ArrayList<>(set);
+        } catch (Exception ex) {
+            return List.of();
+        }
     }
 }

--- a/src/main/java/com/example/MrPot/service/FileExtractionService.java
+++ b/src/main/java/com/example/MrPot/service/FileExtractionService.java
@@ -11,6 +11,7 @@ import org.springframework.util.MimeTypeUtils;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 
 @Service
@@ -42,10 +43,10 @@ public class FileExtractionService {
                 }
 
                 text = clamp(text, MAX_EXTRACT_CHARS);
-                return new ExtractedFile(f.uri(), f.filename(), f.mimeType(), f.sizeBytes(), text, null);
+                return new ExtractedFile(f.uri(), f.filename(), f.mimeType(), f.sizeBytes(), text, null, null, List.of());
 
             } catch (Exception ex) {
-                return new ExtractedFile(f.uri(), f.filename(), f.mimeType(), f.sizeBytes(), "", ex.toString());
+                return new ExtractedFile(f.uri(), f.filename(), f.mimeType(), f.sizeBytes(), "", ex.toString(), null, List.of());
             }
         });
     }
@@ -55,9 +56,9 @@ public class FileExtractionService {
 
         // English comments: Keep instruction short to reduce tokens.
         String instruction =
-                "Extract readable text from the image. " +
-                        "If no text, describe key objects briefly. " +
-                        "Plain text only.";
+                "You are DeepSeek-OCR. Extract readable text from the image. " +
+                        "If the image lacks text, briefly describe the key objects. " +
+                        "Respond with plain text only.";
 
         return visionClient.prompt()
                 .user(u -> u.text(instruction).media(mt, new ByteArrayResource(bytes)))


### PR DESCRIPTION
## Summary
- default the vision model to DeepSeek and tune OCR instructions for image extraction
- run a key-info extraction pass on fetched files to capture JSON summaries and entities
- surface file key info in prompts/progress and expand retrieval queries with extracted entities

## Testing
- mvn -q -DskipTests package *(fails: unable to download parent POM from Maven Central, HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954dfebcb788325a44bebb1c0ddf7d3)