### PR TITLE
Handle image-only uploads in file context

### DIFF
--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -1162,15 +1162,21 @@ public class RagAnswerService {
                 continue;
             }
 
-            if (!safeList(f.keywords()).isEmpty()) {
+            List<String> keywords = safeList(f.keywords());
+            List<String> queries = safeList(f.queries());
+            String txt = safeText(f.keyText());
+
+            if (!keywords.isEmpty()) {
                 sb.append("  keywords: ").append(String.join(", ", uniqLimit(f.keywords(), 12))).append("\n");
             }
-            if (!safeList(f.queries()).isEmpty()) {
+            if (!queries.isEmpty()) {
                 sb.append("  queries: ").append(String.join(" | ", uniqLimit(f.queries(), 6))).append("\n");
             }
-            String txt = safeText(f.keyText());
             if (!txt.isBlank()) {
                 sb.append("  text: ").append(truncate(txt, 900)).append("\n");
+            }
+            if (txt.isBlank() && keywords.isEmpty() && queries.isEmpty() && isImageMime(f.mime())) {
+                sb.append("  note: image provided; no readable text extracted.\n");
             }
             sb.append("\n");
 
@@ -1187,6 +1193,10 @@ public class RagAnswerService {
 
     private static String safe(String s, String d) {
         return (s == null || s.isBlank()) ? d : s;
+    }
+
+    private static boolean isImageMime(String mime) {
+        return mime != null && mime.toLowerCase(Locale.ROOT).startsWith("image/");
     }
 
     private static boolean hasAnyReference(RagRetrievalResult retrieval, String fileText) {


### PR DESCRIPTION
### Motivation
- Ensure photo-only uploads (e.g. a user asking about an uploaded photo) are treated as a form of evidence even when OCR/understanding returns no text.
- Avoid producing entirely empty file context for images which could lead the system to incorrectly mark the request as having no file evidence.
- Make the assistant able to acknowledge image-only inputs like “这是郭育奇小时候的照片” so it can still respond helpfully.

### Description
- Update `buildFileContext` in `RagAnswerService` to compute `keywords`, `queries`, and `txt` once and reuse them when composing the file context.
- Add a note line `note: image provided; no readable text extracted.` when an item is an image MIME and has no extracted text, keywords, or queries.
- Add a helper `isImageMime` that checks `mime` via `mime.toLowerCase(Locale.ROOT).startsWith("image/")`.
- Changes are localized to `src/main/java/com/example/MrPot/service/RagAnswerService.java` and do not alter retrieval or prompt-building logic beyond making the file context richer for image-only uploads.

### Testing
- No automated tests were run for this change.
- Manual verification: code compiles and the updated `buildFileContext` will include the image note when appropriate (no automated test executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1098c1e88325aacbe4bbe1ed144f)