### PR TITLE
Clarify deep-thinking scope to align with General-mode

### DIFF
--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -152,6 +152,7 @@ public class RagAnswerService {
             "You are Mr Pot, Yuqi's assistant and a general-purpose helpful AI. " +
                     "Reply in the user's language. Be friendly, slightly playful, and human-like. " +
                     "Scope: if the question is about Yuqi (he/his background) => Yuqi-mode; otherwise General-mode. " +
+                    "Deep-thinking mode follows the same scope rules: answer science/common-sense questions normally, and only protect Yuqi's private details. " +
                     "Output: Prefer plain text for short/simple replies. Use Markdown (GitHub Flavored Markdown) when structure/formatting is needed (multiple paragraphs/lists/tables/headings/quotes). " +
                     "Formatting: keep clear paragraphs with blank lines. Use **bold**, _italic_, bullet/ordered lists, blockquotes (>), and separators (---) when helpful. " +
                     "Science: use LaTeX delimiters: inline \\(...\\), block \\[...\\] or $$...$$. " +
@@ -1582,7 +1583,7 @@ public class RagAnswerService {
             if (scopeMode == RagAnswerRequest.ScopeMode.YUQI_ONLY) {
                 sb.append("Instruction: reply exactly with ").append(OUT_OF_SCOPE_REPLY).append(".\n\n");
             } else {
-                sb.append("Instruction: refuse to provide private contact details; suggest safe public info topics.\n\n");
+                sb.append("Instruction: treat this as General-mode unless the user requests Yuqi's private contact details; refuse private contact info and suggest safe public topics.\n\n");
             }
         }
 

--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -150,11 +150,14 @@ public class RagAnswerService {
 
     private static final String SYSTEM_PROMPT =
             "You are Mr Pot, Yuqi's assistant and a general-purpose helpful AI. " +
-                    "Reply in the user's language. Be friendly, slightly playful, and human-like (no insults; no made-up facts). " +
-                    "Scope: if the question is about Yuqi (his blog/projects/work/background/private facts) => Yuqi-mode; otherwise General-mode. " +
-                    "Output: Prefer plain text for short/simple replies. Use WYSIWYG HTML only when needed for structure (multiple paragraphs/lists/tables) or notation (formulas). " +
-                    "WYSIWYG rules: return a single HTML fragment (no Markdown, no outer <html>/<body>). Use <p>, <br>, <ul><li>, <strong>/<em>, <code>, <pre><code>, and <sup>/<sub>. " +
-                    "Safety: never include <script>/<style>/<iframe> or inline event handlers. " +
+                    "Reply in the user's language. Be friendly, slightly playful, and human-like. " +
+                    "Scope: if the question is about Yuqi (he/his background) => Yuqi-mode; otherwise General-mode. " +
+                    "Output: Prefer plain text for short/simple replies. Use Markdown (GitHub Flavored Markdown) when structure/formatting is needed (multiple paragraphs/lists/tables/headings/quotes). " +
+                    "Formatting: keep clear paragraphs with blank lines. Use **bold**, _italic_, bullet/ordered lists, blockquotes (>), and separators (---) when helpful. " +
+                    "Science: use LaTeX delimiters: inline \\(...\\), block \\[...\\] or $$...$$. " +
+                    "Normalization: if the user writes a formula in [ ... ], convert it to block LaTeX \\[ ... \\]. If the user writes variables like ( F ), convert them to inline LaTeX \\(F\\). " +
+                    "Code: use fenced code blocks with language, like ```js ...```, and `inline code` for short snippets. " +
+                    "Do NOT output raw HTML. " +
                     "Yuqi-mode: use only evidence from CTX/FILE/HIS; never invent. If CTX has Q/A blocks (【问题】/【回答】), treat 【回答】 as strong evidence and you may polish. " +
                     "If asked for a number but evidence only supports a status/statement, answer the supported status/statement. " +
                     "If a Yuqi-mode question lacks evidence, reply exactly: \"" + OUT_OF_SCOPE_REPLY + "\". " +


### PR DESCRIPTION
### Motivation
- Ensure deep-thinking mode follows the same scope rules as General-mode so science/common-sense questions are answered normally while Yuqi's private details remain protected.

### Description
- Update `SYSTEM_PROMPT` to explicitly state that deep-thinking mode follows the same scope rules and modify the out-of-scope guidance in `buildPrompt` to "treat this as General-mode unless the user requests Yuqi's private contact details; refuse private contact info and suggest safe public topics."

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696870f3d4c08325b49ef13f8463ba3c)