### PR TITLE
Generalize Mr Pot prompt and remove Yuqi-specific heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Mr Pot is a Spring Boot RAG service that streams “thinking” events while ans
 ## Demo
 Link: https://www.yuqi.site/?openChat=1
 
-https://github.com/user-attachments/assets/320f1a1c-d5c3-45b2-9c72-fdb160544cc2
+
+https://github.com/user-attachments/assets/4860a447-ff30-4a9d-a6a3-ede09c0b1f9e
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Mr Pot is a Spring Boot RAG service that streams “thinking” events while answering questions with retrieval, memory, and file-understanding context.
 
+## Demo
+Link: https://www.yuqi.site/?openChat=1
+
+https://github.com/user-attachments/assets/320f1a1c-d5c3-45b2-9c72-fdb160544cc2
+
+
+
 ## Service structure
 ![Deployment UML](./UML.png)
 This project is commonly deployed as a small set of services (e.g., on Railway or with Docker Compose):

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ Swagger UI is available at http://localhost:8080/swagger-ui when the app is runn
 - **ConflictDetectTools**: flags contradictions between retrieved context and attachments.
 - **PrivacySanitizerTools**: scrubs sensitive content from context before use.
 - **CodeSearchTools**: optionally searches a local repo when `mrpot.code.root` is configured.
+- **IntentDetectTools / KeywordExtractTools**: lightweight utility tools that infer user intent and extract keyword hints.
 - **AnswerOutlineTools / AssumptionCheckTools / ActionPlanTools / TrackCorrectTools / EvidenceGapTools**: deep-thinking helpers that outline answers, check assumptions, identify gaps, keep responses on-track, and propose next steps.

--- a/src/main/java/com/example/MrPot/service/CandidateIngestionService.java
+++ b/src/main/java/com/example/MrPot/service/CandidateIngestionService.java
@@ -46,7 +46,8 @@ public class CandidateIngestionService {
             String error,
             String question,
             String answer,
-            Object retrievalDocs
+            Object retrievalDocs,
+            ToolRunSummary toolSummary
     ) {
         String dedupeKey = sha256Base64(safe(sessionId) + "|" + safe(question) + "|" + safe(model) + "|" + safe(error));
 
@@ -55,6 +56,9 @@ public class CandidateIngestionService {
         // Map.of 遇到 null 会 NPE，这里用 LinkedHashMap 更稳
         Map<String, Object> evidenceMap = new LinkedHashMap<>();
         evidenceMap.put("retrieval_docs", retrievalDocs);
+        if (toolSummary != null) {
+            evidenceMap.put("tool_results", buildToolResults(toolSummary));
+        }
 
         String keyStepsJson = toJson(keyInfo.steps());
         String keyPointsJson = toJson(keyInfo.points());
@@ -118,6 +122,10 @@ public class CandidateIngestionService {
             doc.put("key_steps", keyInfo.steps());
             doc.put("key_points", keyInfo.points());
 
+            if (toolSummary != null) {
+                doc.put("tool_results", buildToolResults(toolSummary));
+            }
+
             log.info("ES upsert start: id={}", dedupeKey);
             esIndexer.upsert(dedupeKey, doc);
         } else {
@@ -128,6 +136,75 @@ public class CandidateIngestionService {
     private String toJson(Object value) {
         try { return objectMapper.writeValueAsString(value); }
         catch (Exception e) { return "{}"; }
+    }
+
+    private Map<String, Object> buildToolResults(ToolRunSummary summary) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        if (summary == null) return out;
+
+        if (summary.keyInfo() != null && !summary.keyInfo().isEmpty()) {
+            out.put("key_info", summary.keyInfo());
+        }
+        if (summary.entityTerms() != null && !summary.entityTerms().isEmpty()) {
+            out.put("entity_terms", summary.entityTerms());
+        }
+        if (summary.scopeGuard() != null) {
+            Map<String, Object> scopeGuard = new LinkedHashMap<>();
+            scopeGuard.put("scoped", summary.scopeGuard().scoped());
+            if (summary.scopeGuard().reason() != null) {
+                scopeGuard.put("reason", summary.scopeGuard().reason());
+            }
+            if (summary.scopeGuard().rewriteHint() != null) {
+                scopeGuard.put("rewriteHint", summary.scopeGuard().rewriteHint());
+            }
+            out.put("scope_guard", scopeGuard);
+        }
+        if (summary.intentResult() != null) {
+            Map<String, Object> intent = new LinkedHashMap<>();
+            intent.put("intent", summary.intentResult().intent());
+            intent.put("signals", summary.intentResult().signals());
+            out.put("intent", intent);
+        }
+        if (summary.keywordResult() != null) {
+            Map<String, Object> keywords = new LinkedHashMap<>();
+            keywords.put("items", summary.keywordResult().keywords());
+            keywords.put("source", summary.keywordResult().source());
+            out.put("keywords", keywords);
+        }
+        if (summary.evidenceGap() != null) {
+            Map<String, Object> evidenceGap = new LinkedHashMap<>();
+            evidenceGap.put("status", summary.evidenceGap().status());
+            evidenceGap.put("missing_facts", summary.evidenceGap().missingFacts());
+            evidenceGap.put("follow_ups", summary.evidenceGap().followUps());
+            out.put("evidence_gap", evidenceGap);
+        }
+        if (summary.answerOutline() != null) {
+            Map<String, Object> answerOutline = new LinkedHashMap<>();
+            answerOutline.put("style", summary.answerOutline().style());
+            answerOutline.put("sections", summary.answerOutline().sections());
+            out.put("answer_outline", answerOutline);
+        }
+        if (summary.assumptionResult() != null) {
+            Map<String, Object> assumptionCheck = new LinkedHashMap<>();
+            assumptionCheck.put("risk", summary.assumptionResult().riskLevel());
+            assumptionCheck.put("assumptions", summary.assumptionResult().assumptions());
+            out.put("assumption_check", assumptionCheck);
+        }
+        if (summary.actionPlan() != null) {
+            Map<String, Object> actionPlan = new LinkedHashMap<>();
+            actionPlan.put("style", summary.actionPlan().style());
+            actionPlan.put("steps", summary.actionPlan().steps());
+            out.put("action_plan", actionPlan);
+        }
+        if (summary.trackCorrectResult() != null) {
+            Map<String, Object> trackCorrect = new LinkedHashMap<>();
+            trackCorrect.put("on_track", summary.trackCorrectResult().onTrack());
+            trackCorrect.put("status", summary.trackCorrectResult().status());
+            trackCorrect.put("hint", summary.trackCorrectResult().hint());
+            out.put("track_correct", trackCorrect);
+        }
+
+        return out;
     }
 
     private static String safe(String value) { return value == null ? "" : value; }

--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -195,6 +195,8 @@ public class RagAnswerService {
                     "Reply in the user's language. Be friendly, slightly playful, and human-like. " +
                     "Privacy: if the user asks for Yuqi's private/personal details, refuse with a light humorous response and offer safe alternatives or public/professional topics. " +
                     "Otherwise answer normally like a standard LLM agent. " +
+                    "Yuqi-mode: use only evidence from CTX/FILE/HIS; never invent. If CTX has Q/A blocks (【问题】/【回答】), treat 【回答】 as strong evidence and you may polish. " +
+                    "If asked for a number but evidence only supports a status/statement, answer the supported status/statement. " +
                     "Output: Prefer plain text for short/simple replies. Use Markdown (GitHub Flavored Markdown) when structure/formatting is needed (multiple paragraphs/lists/tables/headings/quotes). " +
                     "Formatting: keep clear paragraphs with blank lines. Use **bold**, _italic_, bullet/ordered lists, blockquotes (>), and separators (---) when helpful. " +
                     "Science: use LaTeX delimiters: inline \\(...\\), block \\[...\\] or $$...$$. " +

--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -150,11 +150,14 @@ public class RagAnswerService {
 
     private static final String SYSTEM_PROMPT =
             "You are Mr Pot, Yuqi's assistant and a general-purpose helpful AI. " +
-                    "Reply in the user's language. Be friendly, slightly playful, and human-like (no insults; no made-up facts). " +
-                    "Scope: if the question is about Yuqi (his blog/projects/work/background/private facts) => Yuqi-mode; otherwise General-mode. " +
-                    "Output: Prefer plain text for short/simple replies. Use WYSIWYG HTML only when needed for structure (multiple paragraphs/lists/tables) or notation (formulas). " +
-                    "WYSIWYG rules: return a single HTML fragment (no Markdown, no outer <html>/<body>). Use <p>, <br>, <ul><li>, <strong>/<em>, <code>, <pre><code>, and <sup>/<sub>. " +
-                    "Safety: never include <script>/<style>/<iframe> or inline event handlers. " +
+                    "Reply in the user's language. Be friendly, slightly playful, and human-like. " +
+                    "Scope: if the question is about Yuqi (he/his background) => Yuqi-mode; otherwise General-mode. " +
+                    "Output: Prefer plain text for short/simple replies. Use Markdown (GitHub Flavored Markdown) when structure/formatting is needed (multiple paragraphs/lists/tables/headings/quotes). " +
+                    "Formatting: keep clear paragraphs with blank lines. Use **bold**, _italic_, bullet/ordered lists, blockquotes (>), and separators (---) when helpful. " +
+                    "Science: use LaTeX delimiters: inline \\(...\\), block \\[...\\] or $$...$$. " +
+                    "Normalization: if the user writes a formula in [ ... ], convert it to block LaTeX \\[ ... \\]. If the user writes variables like ( F ), convert them to inline LaTeX \\(F\\). " +
+                    "Code: use fenced code blocks with language, like ```js ...```, and `inline code` for short snippets. " +
+                    "Do NOT output raw HTML. " +
                     "Yuqi-mode: use only evidence from CTX/FILE/HIS; never invent. If CTX has Q/A blocks (【问题】/【回答】), treat 【回答】 as strong evidence and you may polish. " +
                     "If asked for a number but evidence only supports a status/statement, answer the supported status/statement. " +
                     "If a Yuqi-mode question lacks evidence, reply exactly: \"" + OUT_OF_SCOPE_REPLY + "\". " +

--- a/src/main/java/com/example/MrPot/service/ToolRunSummary.java
+++ b/src/main/java/com/example/MrPot/service/ToolRunSummary.java
@@ -1,0 +1,18 @@
+package com.example.MrPot.service;
+
+import com.example.MrPot.tools.*;
+
+import java.util.List;
+
+public record ToolRunSummary(
+        List<String> keyInfo,
+        EvidenceGapTools.EvidenceGapResult evidenceGap,
+        AnswerOutlineTools.OutlineResult answerOutline,
+        AssumptionCheckTools.AssumptionResult assumptionResult,
+        ActionPlanTools.ActionPlanResult actionPlan,
+        ScopeGuardTools.ScopeGuardResult scopeGuard,
+        List<String> entityTerms,
+        IntentDetectTools.IntentResult intentResult,
+        KeywordExtractTools.KeywordResult keywordResult,
+        TrackCorrectTools.TrackResult trackCorrectResult
+) {}

--- a/src/main/java/com/example/MrPot/tools/IntentDetectTools.java
+++ b/src/main/java/com/example/MrPot/tools/IntentDetectTools.java
@@ -1,0 +1,55 @@
+package com.example.MrPot.tools;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+@Component
+public class IntentDetectTools {
+
+    private static final Pattern DEBUG_HINT = Pattern.compile("(debug|error|issue|fix|\\u9519\\u8bef|\\u95ee\\u9898|\\u4fee\\u590d)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern STRATEGY_HINT = Pattern.compile("(strategy|plan|roadmap|\\u7b56\\u7565|\\u89c4\\u5212)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEARN_HINT = Pattern.compile("(learn|study|practice|\\u5b66\\u4e60|\\u7ec3\\u4e60)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern HOWTO_HINT = Pattern.compile("(how to|guide|tutorial|\\u600e\\u4e48|\\u5982\\u4f55|\\u6559\\u7a0b)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern COMPARE_HINT = Pattern.compile("(compare|vs\\.?|difference|\\u5bf9\\u6bd4|\\u533a\\u522b)", Pattern.CASE_INSENSITIVE);
+
+    public record IntentResult(String intent, List<String> signals) {}
+
+    @Tool(name = "intent_detect", description = "Detect the user's high-level intent to guide response tone and structure.")
+    public IntentResult detect(String question) {
+        String q = question == null ? "" : question.trim();
+        String lower = q.toLowerCase(Locale.ROOT);
+        List<String> signals = new ArrayList<>();
+
+        if (DEBUG_HINT.matcher(lower).find()) {
+            signals.add("debug");
+            return new IntentResult("debug", signals);
+        }
+        if (STRATEGY_HINT.matcher(lower).find()) {
+            signals.add("strategy");
+            return new IntentResult("plan", signals);
+        }
+        if (LEARN_HINT.matcher(lower).find()) {
+            signals.add("learn");
+            return new IntentResult("learn", signals);
+        }
+        if (HOWTO_HINT.matcher(lower).find()) {
+            signals.add("howto");
+            return new IntentResult("howto", signals);
+        }
+        if (COMPARE_HINT.matcher(lower).find()) {
+            signals.add("compare");
+            return new IntentResult("compare", signals);
+        }
+
+        if (!q.isBlank()) {
+            signals.add("general");
+        }
+
+        return new IntentResult("general", signals);
+    }
+}

--- a/src/main/java/com/example/MrPot/tools/KeywordExtractTools.java
+++ b/src/main/java/com/example/MrPot/tools/KeywordExtractTools.java
@@ -1,0 +1,65 @@
+package com.example.MrPot.tools;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class KeywordExtractTools {
+
+    private static final Pattern TOKEN = Pattern.compile("[\\p{IsAlphabetic}\\p{IsDigit}]+");
+    private static final Set<String> STOPWORDS = Set.of(
+            "the", "a", "an", "and", "or", "to", "of", "in", "on", "for", "with", "by", "from",
+            "is", "are", "was", "were", "be", "been", "this", "that", "these", "those", "it",
+            "you", "your", "me", "my", "we", "our", "they", "their", "he", "she", "his", "her",
+            "how", "what", "why", "when", "where", "which"
+    );
+
+    public record KeywordResult(List<String> keywords, String source) {}
+
+    @Tool(name = "keyword_extract", description = "Extract lightweight keyword candidates from question/context for retrieval hints.")
+    public KeywordResult extract(String question, List<String> keyInfo, List<String> entityTerms, int limit) {
+        LinkedHashSet<String> out = new LinkedHashSet<>();
+        StringBuilder sourceBuilder = new StringBuilder();
+
+        if (question != null && !question.isBlank()) {
+            sourceBuilder.append(question).append(" ");
+        }
+        if (keyInfo != null && !keyInfo.isEmpty()) {
+            for (String item : keyInfo) {
+                if (item == null || item.isBlank()) continue;
+                sourceBuilder.append(item).append(" ");
+            }
+        }
+        if (entityTerms != null && !entityTerms.isEmpty()) {
+            for (String term : entityTerms) {
+                if (term == null || term.isBlank()) continue;
+                out.add(term.trim());
+            }
+        }
+
+        String source = sourceBuilder.toString();
+        Matcher matcher = TOKEN.matcher(source);
+        while (matcher.find()) {
+            String token = matcher.group().toLowerCase(Locale.ROOT);
+            if (token.length() < 2) continue;
+            if (STOPWORDS.contains(token)) continue;
+            out.add(token);
+            if (limit > 0 && out.size() >= limit) break;
+        }
+
+        List<String> keywords = new ArrayList<>(out);
+        if (limit > 0 && keywords.size() > limit) {
+            keywords = keywords.subList(0, limit);
+        }
+
+        return new KeywordResult(keywords, source.isBlank() ? "none" : "question+context");
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace Yuqi-specific behavior with a general assistant persona while still refusing Yuqi's private/personal detail requests in a light humorous way. 
- Remove fragile keyword heuristics for privacy/Yuqi detection and rely on the existing `scope_guard` outputs and evidence grounding instead.

### Description
- Updated the `SYSTEM_PROMPT` in `RagAnswerService` to present Mr Pot as a general-purpose assistant and to instruct a humorous refusal for Yuqi privacy requests while encouraging grounded answers when `CTX/FILE/HIS` exist. 
- Removed the heuristic methods `looksLikePrivacyRequest` and `looksLikeYuqiQuestion` and all direct uses of those keyword detectors. 
- Simplified scope/metadata logic by using the `ScopeGuardTools.ScopeGuardResult` directly (adjusted `trackCorrectMono` status logic and prompt metadata assembly) and removed Yuqi-mode forced fallback to the `OUT_OF_SCOPE_REPLY` literal. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697305a91fc8832597a4945fdd999973)