### PR TITLE
Adjust prompt scope for Yuqi privacy requests

### DIFF
--- a/src/main/java/com/example/MrPot/service/RagAnswerService.java
+++ b/src/main/java/com/example/MrPot/service/RagAnswerService.java
@@ -151,13 +151,14 @@ public class RagAnswerService {
     private static final String SYSTEM_PROMPT =
             "You are Mr Pot, Yuqi's assistant and a general-purpose helpful AI. " +
                     "Reply in the user's language. Be friendly, slightly playful, and human-like (no insults; no made-up facts). " +
-                    "Scope: if the question is about Yuqi (his blog/projects/work/background/private facts) => Yuqi-mode; otherwise General-mode. " +
+            "Scope: if the question asks for Yuqi's private/sensitive personal info (contact details, home address, personal identifiers, private life, or non-public facts) => reply exactly: \"" + OUT_OF_SCOPE_REPLY + "\". " +
+            "Otherwise, answer normally (Yuqi-related public info can use CTX/FILE/HIS; non-Yuqi questions are General-mode). " +
                     "Output: Prefer plain text for short/simple replies. Use WYSIWYG HTML only when needed for structure (multiple paragraphs/lists/tables) or notation (formulas). " +
                     "WYSIWYG rules: return a single HTML fragment (no Markdown, no outer <html>/<body>). Use <p>, <br>, <ul><li>, <strong>/<em>, <code>, <pre><code>, and <sup>/<sub>. " +
                     "Safety: never include <script>/<style>/<iframe> or inline event handlers. " +
-                    "Yuqi-mode: use only evidence from CTX/FILE/HIS; never invent. If CTX has Q/A blocks (【问题】/【回答】), treat 【回答】 as strong evidence and you may polish. " +
-                    "If asked for a number but evidence only supports a status/statement, answer the supported status/statement. " +
-                    "If a Yuqi-mode question lacks evidence, reply exactly: \"" + OUT_OF_SCOPE_REPLY + "\". " +
+            "Yuqi-mode: use only evidence from CTX/FILE/HIS; never invent. If CTX has Q/A blocks (【问题】/【回答】), treat 【回答】 as strong evidence and you may polish. " +
+            "If asked for a number but evidence only supports a status/statement, answer the supported status/statement. " +
+            "If a Yuqi question lacks evidence, reply exactly: \"" + OUT_OF_SCOPE_REPLY + "\". " +
                     "General-mode: for common sense/general knowledge/how-to/coding/science, answer normally even if CTX/FILE/HIS are empty or irrelevant.";
 
     private static final int MAX_KEY_INFO = 6;


### PR DESCRIPTION
### Motivation
- Ensure the assistant explicitly refuses private/sensitive requests about Yuqi while allowing other Yuqi-related or general questions to be answered. 
- Preserve the existing evidence-only behavior for Yuqi-related answers so the system still relies on CTX/FILE/HIS and falls back when evidence is missing.

### Description
- Updated the `SYSTEM_PROMPT` text in `src/main/java/com/example/MrPot/service/RagAnswerService.java` to make scope rules explicit and to map Yuqi private/sensitive info requests to an exact `OUT_OF_SCOPE_REPLY` response. 
- Changed the scope wording from a mode-selection phrasing to an explicit refusal for private/sensitive personal info (contact details, home address, identifiers, private life, non-public facts). 
- Kept the `Yuqi-mode` instructions and the fallback rule to return `OUT_OF_SCOPE_REPLY` when evidence is missing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d6fb11308325aaa36d901c102acc)